### PR TITLE
gen: simplify the config format for Go files

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ['stable', 'oldstable']
+        go-version: ['stable']
         os: ['ubuntu-latest']
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ To generate types from a separate config file, add a rule like this:
 //go:generate enumgen -config enums.yml -output generated.go
 ```
 
-Alternatively, you may embed the YAML config inside a Go source file (detected
-by a name ending in ".go"), in a comment group prefixed by `enumgen:config`:
+Alternatively, you may embed the YAML definition of a [`gen.Enum`][ge] inside a
+Go source file (detected by a name ending in ".go"), in a comment group
+prefixed by `enumgen:type`:
 
 ```go
 //go:generate enumgen -config thisfile.go -output generated.go
@@ -25,30 +26,29 @@ by a name ending in ".go"), in a comment group prefixed by `enumgen:config`:
 // Note there may be no space before the annotation, and the annotation
 // must be the first line of its comment group.
 
-//enumgen:config
-/*
+/*enumgen:type Color
+
 # Inside this comment everything is YAML.
 # Probably I should be ashamed of myself for this.
 
-package: example
-enum:
-  - type: Color
-    doc: |
-      A Color is a source of joy for all who behold it.
-    flag-value: true
-    values:
-      - name: Red
-        text: fire-engine-red
+doc: |
+  A Color is a source of joy for all who behold it.
+flag-value: true
+values:
+  - name: Red
+    text: fire-engine-red
 
-      - name: Green
-        text: scummy-green
+  - name: Green
+    text: scummy-green
 
-      - name: Blue
-        text: azure-sky-blue
+  - name: Blue
+    text: azure-sky-blue
 */
 ```
 
-If there are multiple such blocks in the file, only the first is considered.
+There may be multiple such blocks in a file; each defines a single enumeration.
+The text after `enumgen:type` becomes the name of the type; the content of the
+block must be a single [`gen.Enum`][ge] value.
 
 ## Type Structure
 
@@ -88,3 +88,4 @@ single package. The general structure of a config in YAML follows this example
 
 [gogen]: https://go.dev/blog/generate
 [gc]: https://godoc.org/github.com/creachadair/enumgen/gen#Config
+[ge]: https://godoc.org/github.com/creachadair/enumgen/gen#Enum

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -184,6 +184,15 @@ func TestEnums(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("ColorFlag", func(t *testing.T) {
+		const redText = "fire-engine-red"
+		color := testdata.Red
+		if got := color.String(); got != redText {
+			t.Errorf("Red: got %q, want %q", got, redText)
+		}
+		var _ flag.Value = &color
+	})
 }
 
 func TestErrors(t *testing.T) {

--- a/gen/testdata/enums.go
+++ b/gen/testdata/enums.go
@@ -112,4 +112,4 @@ var (
 
 // GeneratorHash is used by the tests to verify that the testdata
 // package is updated when the code generator changes.
-const GeneratorHash = "5274b7696e9111acfc862c687a0b24a8819753a1b8054663195e7c95a1f7ae5b"
+const GeneratorHash = "dd48f27842f8fac87bde3ae49d11606775c1718b724682d175f25f47947e6284"

--- a/gen/testdata/gofile.go
+++ b/gen/testdata/gofile.go
@@ -2,6 +2,8 @@
 
 package testdata
 
+import "fmt"
+
 // An enumeration defined in a Go file.
 type E4 struct{ *string }
 
@@ -25,4 +27,41 @@ var (
 	E4_P = E4{&_str_E4[0]}
 	E4_D = E4{&_str_E4[1]}
 	E4_Q = E4{&_str_E4[2]}
+)
+
+// A Color is a source of joy for all who behold it.
+type Color struct{ *string }
+
+// Enum returns the name of the enumeration type for Color.
+func (Color) Enum() string { return "Color" }
+
+// String returns the string representation of Color v.
+func (v Color) String() string {
+	if v.string == nil {
+		return "<invalid>"
+	}
+	return *v.string
+}
+
+// Valid reports whether v is a valid Color value.
+func (v Color) Valid() bool { return v.string != nil }
+
+// Set implements part of the flag.Value interface for Color.
+// A value must equal the string representation of an enumerator.
+func (v *Color) Set(s string) error {
+	for i, opt := range _str_Color {
+		if opt == s {
+			v.string = &_str_Color[i]
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid value for Color: %q", s)
+}
+
+var (
+	_str_Color = []string{"fire-engine-red", "scummy-green", "azure-sky-blue"}
+
+	Red   = Color{&_str_Color[0]}
+	Green = Color{&_str_Color[1]}
+	Blue  = Color{&_str_Color[2]}
 )

--- a/gen/testdata/testdata.go
+++ b/gen/testdata/testdata.go
@@ -2,15 +2,28 @@ package testdata
 
 //go:generate ./gen.sh
 
-/*enumgen:config
+/*enumgen:type E4
 
-# package testdata inferred from file
-enum:
-  - type: E4
-    doc: An enumeration defined in a Go file.
-    prefix: E4_
-    values:
-      - name: P
-      - name: D
-      - name: Q
+# package testdata inferred from the declaration above.
+# type name assigned by the enumgen: comment.
+doc: An enumeration defined in a Go file.
+prefix: E4_
+values:
+  - name: P
+  - name: D
+  - name: Q
 */
+
+//enumgen:type Color
+// doc: |
+//   A Color is a source of joy for all who behold it.
+// flag-value: true
+// values:
+//   - name: Red
+//     text: fire-engine-red
+//
+//   - name: Green
+//     text: scummy-green
+//
+//   - name: Blue
+//     text: azure-sky-blue

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/creachadair/enumgen
 
-go 1.19
+go 1.20
 
 require (
 	github.com/creachadair/mds v0.0.1


### PR DESCRIPTION
Instead of requiring a complete config inside a comment, extract only the gen.Enum value. This also makes it possible to support multiple such comment blocks in a given file, so multiple types can be defined separately.

Rename the tag "enumgen:type", and extract the type name from the remainder of that line.