### PR TITLE
gen: allow specifying docs and text for the zero value

### DIFF
--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -88,6 +88,14 @@ func TestEnums(t *testing.T) {
 		check(t, testdata.E4_Q, true, "Q")
 	})
 
+	t.Run("Count", func(t *testing.T) {
+		var zero testdata.Count
+		check(t, zero, false, "zilch")
+		check(t, testdata.Zero, false, "zilch")
+		check(t, testdata.One, true, "lonely")
+		check(t, testdata.Two, true, "tango")
+	})
+
 	t.Run("E1Index", func(t *testing.T) {
 		var zero testdata.E1
 		for i, e := range []testdata.E1{zero, testdata.A, testdata.B, testdata.C} {
@@ -263,12 +271,6 @@ func TestErrors(t *testing.T) {
 		}},
 
 		// Check for name collisions with default (zero) enumerators.
-		{`"X" conflicts with default`, &gen.Config{
-			Package: "foo",
-			Enum: []*gen.Enum{
-				{Type: "bar", Zero: "X", Values: []*gen.Value{{Name: "X"}}},
-			},
-		}},
 		{`name "X" duplicated in "bar"`, &gen.Config{
 			Package: "foo",
 			Enum: []*gen.Enum{

--- a/gen/testdata/enums.go
+++ b/gen/testdata/enums.go
@@ -117,6 +117,28 @@ var (
 	Y = E3{2}
 )
 
+type Count struct{ _Count uint8 }
+
+// Enum returns the name of the enumeration type for Count.
+func (Count) Enum() string { return "Count" }
+
+// Index returns the ordinal index of Count v.
+func (v Count) Index() int { return int(v._Count) }
+
+// String returns the string representation of Count v.
+func (v Count) String() string { return _str_Count[v._Count] }
+
+// Valid reports whether v is a valid Count value.
+func (v Count) Valid() bool { return v._Count > 0 && int(v._Count) < len(_str_Count) }
+
+var (
+	_str_Count = []string{"zilch", "lonely", "tango"}
+
+	Zero = Count{0} // Nothing to see here
+	One  = Count{1} // The very loneliest
+	Two  = Count{2}
+)
+
 // GeneratorHash is used by the tests to verify that the testdata
 // package is updated when the code generator changes.
-const GeneratorHash = "566209aaf46516347d8ba29d2125ed5b98a566c3f2f6646de9be556d2de68ea9"
+const GeneratorHash = "ac125d41de567118ef359373c2b29b7fe6d4f1779353d6a173b0a8012b7549d6"

--- a/gen/testdata/gentest.yml
+++ b/gen/testdata/gentest.yml
@@ -27,3 +27,17 @@ enum:
         text: foo
       - name: Y
         text: bar
+
+  - type: Count
+    zero: Zero
+    values:
+      - name: One
+        text: lonely
+        doc: The very loneliest
+
+      - name: Two
+        text: tango
+
+      - name: Zero
+        text: zilch
+        doc: Nothing to see here


### PR DESCRIPTION
The values list may now include an entry for the name specified as the zero for
the enumeration, and in that case the text and documentation on that value will
replace the defaults for the generated enumerator.

The zero enumerator always has index 0, even if explicitly listed.
